### PR TITLE
to_str_openfst

### DIFF
--- a/k2/csrc/fsa_utils.cu
+++ b/k2/csrc/fsa_utils.cu
@@ -616,20 +616,24 @@ std::string FsaToString(const Fsa &fsa, bool openfst, /*= false*/
   char line_sep = '\n';
   for (int32_t a = 0; a != num_arcs; ++a) {
     const auto &arc = arcs[a];
-    os << arc.src_state << sep << arc.dest_state << sep << arc.label << sep;
-    for (int32_t i = 0; i < num_aux_labels; ++i)
-      os << aux_labels_data[i][a] << sep;
-    for (int32_t i = 0; i < num_ragged_labels; ++i) {
-      os << "[ ";
-      for (int32_t j = ragged_labels_row_splits_data[i][a];
-           j < ragged_labels_row_splits_data[i][a+1]; ++j)
-        os << ragged_labels_data[i][j] << sep;
-      os << "] ";
+    if (openfst & arc.label == -1) {
+      os << arc.src_state << sep;
+    } else {
+      os << arc.src_state << sep << arc.dest_state << sep << arc.label << sep;
+      for (int32_t i = 0; i < num_aux_labels; ++i)
+        os << aux_labels_data[i][a] << sep;
+      for (int32_t i = 0; i < num_ragged_labels; ++i) {
+        os << "[ ";
+        for (int32_t j = ragged_labels_row_splits_data[i][a];
+             j < ragged_labels_row_splits_data[i][a+1]; ++j)
+          os << ragged_labels_data[i][j] << sep;
+        os << "] ";
+      }
     }
     os << (scale * arc.score) << line_sep;
   }
 
-  if (num_arcs > 0) {
+  if (num_arcs > 0 & !openfst) {
     int32_t final_state = fsa.shape.Dim0() - 1;
     os << final_state << line_sep;
   } else {


### PR DESCRIPTION
Before: k2.Fsa.from_str(openfsat=True) failed to accept the output of k2.to_str(openfst=True)
<img width="927" alt="image" src="https://user-images.githubusercontent.com/14951566/196347349-188f926c-0108-4e58-809c-a9a0201a905b.png">

Previous problem is fixed by this pr and "openfst=False" is not affected:

<img width="967" alt="image" src="https://user-images.githubusercontent.com/14951566/196347666-27ee9fe6-c109-4e70-99d3-bb69603e5933.png">
